### PR TITLE
Add .funcignore for remote build and add remoteBuild to azure.yaml

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -1,0 +1,6 @@
+*.js.map
+.git*
+.vscode
+local.settings.json
+test
+node_modules

--- a/azure.yaml
+++ b/azure.yaml
@@ -8,6 +8,7 @@ services:
     project: .
     language: js
     host: function
+    remoteBuild: true
 hooks:
   postprovision:
     windows:

--- a/azure.yaml
+++ b/azure.yaml
@@ -6,7 +6,7 @@ metadata:
 services:
   api:
     project: .
-    language: js
+    language: ts
     host: function
     remoteBuild: true
 hooks:


### PR DESCRIPTION
## Summary

Adds missing `.funcignore` and configures the project for remote build when deploying with `azd`.

## Changes

- **azure.yaml**: Added `remoteBuild: true` under the `api` service
- **.funcignore**: Created new file configured for remote build (ignores `node_modules`, does not ignore `*.ts` or `tsconfig.json`)

## Context

When deploying Node.js/TypeScript Azure Functions apps with `azd`, remote build is used. This repo was missing a `.funcignore` file entirely, which means all files including `node_modules` would be uploaded during deployment. This change adds a properly configured `.funcignore` and opts into remote build explicitly.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.